### PR TITLE
Fix unit tests

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -149,14 +149,14 @@ function parseCapsForInnerDriver (jsonwpCapabilities, w3cCapabilities, constrain
  * This helper method tries to fix corrupted W3C capabilities by
  * merging them to existing JSONWP capabilities.
  *
- * @param {Objetc} w3cCaps W3C capabilities
+ * @param {Object} w3cCaps W3C capabilities
  * @param {Object} jsonwpCaps JSONWP capabilities
  * @returns {Object} Fixed W3C capabilities
  */
 function fixW3cCapabilities (w3cCaps, jsonwpCaps) {
   const result = {
-    firstMatch: w3cCaps.firstMatch,
-    alwaysMatch: w3cCaps.alwaysMatch,
+    firstMatch: w3cCaps.firstMatch || [],
+    alwaysMatch: w3cCaps.alwaysMatch || {},
   };
   const keysToInsert = _.keys(jsonwpCaps);
   const removeMatchingKeys = (match) => {
@@ -169,14 +169,17 @@ function fixW3cCapabilities (w3cCaps, jsonwpCaps) {
       _.pull(keysToInsert, `${W3C_APPIUM_PREFIX}:${match}`);
     }
   };
+
   for (const firstMatchEntry of result.firstMatch) {
     for (const pair of _.toPairs(firstMatchEntry)) {
       removeMatchingKeys(pair[0]);
     }
   }
-  for (const pair of result.alwaysMatch) {
+
+  for (const pair of _.toPairs(result.alwaysMatch)) {
     removeMatchingKeys(pair[0]);
   }
+
   for (const key of keysToInsert) {
     result.alwaysMatch[key] = jsonwpCaps[key];
   }

--- a/test/driver-e2e-specs.js
+++ b/test/driver-e2e-specs.js
@@ -160,7 +160,7 @@ describe('FakeDriver - via HTTP', function () {
       await request.delete({ url: `${baseUrl}/${value.sessionId}` });
     });
 
-    it('should accept a combo of W3C and JSONWP but use JSONWP if desiredCapabilities contains extraneous keys', async function () {
+    it('should accept a combo of W3C and JSONWP and if JSONWP has extraneous keys, they should be merged into W3C capabilities', async function () {
       const combinedCaps = {
         "desiredCapabilities": {
           ...caps,
@@ -176,17 +176,18 @@ describe('FakeDriver - via HTTP', function () {
       };
 
       const {sessionId, status, value} = await request.post({url: baseUrl, json: combinedCaps});
-      status.should.exist;
-      sessionId.should.exist;
-      should.not.exist(value.sessionId);
-      value.should.deep.equal({
+      should.not.exist(sessionId);
+      should.not.exist(status);
+      value.sessionId.should.exist;
+      value.capabilities.should.deep.equal({
         ...caps,
         automationName: 'Fake',
         anotherParam: 'Hello',
+        w3cParam: 'w3cParam',
       });
 
       // End session
-      await request.delete({ url: `${baseUrl}/${sessionId}` });
+      await request.delete({ url: `${baseUrl}/${value.sessionId}` });
     });
 
     it('should reject bad W3C capabilities with a BadParametersError (400)', async function () {

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -147,8 +147,17 @@ describe('AppiumDriver', function () {
           someOtherParam: 'someOtherParam',
         };
 
+        let expectedW3cCaps = {
+          ...w3cCaps,
+          alwaysMatch: {
+            ...w3cCaps.alwaysMatch,
+            'appium:automationName': 'Fake',
+            'appium:someOtherParam': 'someOtherParam',
+          },
+        };
+
         mockFakeDriver.expects("createSession")
-          .once().withArgs(jsonwpCaps, undefined, null)
+          .once().withArgs(jsonwpCaps, undefined, expectedW3cCaps)
           .returns([SESSION_ID, jsonwpCaps]);
 
         await appium.createSession(jsonwpCaps, undefined, w3cCaps);


### PR DESCRIPTION
* Does not fall back to MJSONWP anymore when extraneous params, updates tests to reflect that
* Fixed a bug in `lib/utils.js` that tries iterating over `alwaysMatch` or `firstMatch` when undefined by setting defaults